### PR TITLE
Fix implicit-fallthrough compile error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SRC =		$(patsubst %.c,%.o,$(wildcard ${SRC_PATH}/*.c)) \
 
 LINK_ARG =	-lpthread ${LDFLAGS}
 COMPILE_ARG =	-g -iquote ${SRC_PATH} -Wimplicit -Werror -Wall -Wextra \
+		-Wno-implicit-fallthrough \
 		-Wno-unused-result -Wno-missing-field-initializers \
 		-Wno-unused-parameter -Wno-sign-compare --std=gnu99 \
 		-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DVERSION=\"${VERSION}\" \


### PR DESCRIPTION
This code block was causing a compile error:

```c
switch (tolower(*ptr)) {
  default: return false;
  case 'p': ap *= 1024;
  case 't': ap *= 1024;
  case 'g': ap *= 1024;
  case 'm': ap *= 1024;
  case 'k': ap *= 1024;
  case 'i':
  case 'b': break;
}
```

It was fixed by ignoring implicit-fallthrough errors.